### PR TITLE
(lite) Fix lifetime documentation of TfLiteModel

### DIFF
--- a/tensorflow/lite/c/c_api.h
+++ b/tensorflow/lite/c/c_api.h
@@ -147,8 +147,7 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetErrorReporter(
 // failure.
 //
 // * `model` must be a valid model instance. The caller retains ownership of the
-//   object, and can destroy it immediately after creating the interpreter; the
-//   interpreter will maintain its own reference to the underlying model data.
+//   object, and the model must outlive the interpreter.
 // * `optional_options` may be null. The caller retains ownership of the object,
 //   and can safely destroy it immediately after creating the interpreter.
 //


### PR DESCRIPTION
Fixes misleading documentation of `TfLiteInterpreterCreate`. It was stating that a model was destroyable immediately after creating an interpreter, see details in [this issue](https://github.com/tensorflow/tensorflow/issues/53628).